### PR TITLE
fix imgUrl too large

### DIFF
--- a/packages/client/src/treeview/local.ts
+++ b/packages/client/src/treeview/local.ts
@@ -132,9 +132,9 @@ export class LocalProvider implements TreeDataProvider<Content> {
               mv: undefined,
             };
 
-            if (common.picture?.length && common.picture.length < 1024) {
+            if (common.picture?.length) {
               const [{ data, format }] = common.picture;
-              item.al.picUrl = `data:${format};base64,${data.toString("base64")}`;
+              if (data.length < 1024) item.al.picUrl = `data:${format};base64,${data.toString("base64")}`;
             }
 
             items.push(LocalFileTreeItem.new(item));


### PR DESCRIPTION
"common.picture.length" indicates the number of covers in the file, which is always 1. "data.length" is the size of the image file. In fact, there is also a problem, 1024 bytes only 1kb, which cannot hold any image files.